### PR TITLE
Fix getPitches route bug

### DIFF
--- a/server/routes/Pitches.js
+++ b/server/routes/Pitches.js
@@ -4,7 +4,7 @@ module.exports.getPitches = (req, res, next) => {
   const { q, pitchId, cat, userId } = req.query;
 
   if (q === 'all') {
-    if(req.session.passport) {
+    if(req.session.passport && req.session.passport.user) {
       Pitch.getAllPitches(req.session.passport.user.rows[0].id)
         .then(results => {
           res.status(200).send(results.rows)


### PR DESCRIPTION
When page loads, the fetchPitches action is dispatched. Previously, if a user loads the page and is not signed in, req.session.passport.user is undefined which was breaking the logic in the routes/Pitches file. I added an if statement to this logic to ensure we are checking that the user actually exists; now, if the user doesn't exist (is not logged in) the server will instead just retrieve all pitches. 