### PR TITLE
Redirect user to Home page after sign-up

### DIFF
--- a/client/src/actions/createUser.js
+++ b/client/src/actions/createUser.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { signIn } from './signIn';
 
 export function editUsername(username) {
   return {
@@ -48,8 +49,10 @@ function userSubmitted() {
 export function submitUser(username, password, profile, email) {
   return (dispatch) => {
     dispatch(creatingUser())
+    console.log('submitting user')
     axios.post('http://localhost:8080/api/users', {username, password, email, profile })
-    .then( results => dispatch(userSubmitted()))
+    .then(results => dispatch(userSubmitted()))
+    .then(results => dispatch(signIn(username, password)))
     .catch( error => dispatch(creatingUserError(error)))
   }
 }

--- a/client/src/actions/createUser.js
+++ b/client/src/actions/createUser.js
@@ -49,7 +49,6 @@ function userSubmitted() {
 export function submitUser(username, password, profile, email) {
   return (dispatch) => {
     dispatch(creatingUser())
-    console.log('submitting user')
     axios.post('http://localhost:8080/api/users', {username, password, email, profile })
     .then(results => dispatch(userSubmitted()))
     .then(results => dispatch(signIn(username, password)))

--- a/client/src/components/SignUp.jsx
+++ b/client/src/components/SignUp.jsx
@@ -30,7 +30,10 @@ class SignUp extends Component {
             <Header as='h1' floated='left'>Sign Up</Header>
             <Header as='h5' floated='right'>Already have an account? Sign in here</Header>
           </Segment>
-          <Form onSubmit={()=> {dispatch(submitUser(username, password, profile, email))}}>
+          <Form onSubmit={(e)=> {
+            e.preventDefault();
+            submitUser(username, password, profile, email)
+          }}>
             <Form.Input label='Name' onChange={(e)=>{changeUsername(e.target.value)}} />
             <Form.Input label='Email' onChange={(e)=>{changeEmail(e.target.value)}} />
             <Form.Input label='Re-Enter Email' />


### PR DESCRIPTION
When a user signs up, after we add them to the database via a POST to api/users, we will dispatch a userSubmitted action followed by a signIn action which will send them straight to the same authorization route we use when a user signs in. When a user is successfully authorized, they will be redirected to the home page (this redirect is a funky solution that Ed/Craig/Alison implemented - we would still like to change this to use React Router if possible).

To allow these events to actually happen, I added a preventDefault to the form submission in the SignUp component. 